### PR TITLE
Chore/add code coverage config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 package-lock.json
 build/*
 transpiled.js
+coverage/

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ To watch the changes made in the test scripts, use;
 npm run test:watch
 ~~~
 
+##### Code Coverage
+Jest includes the ability to analyze test code coverage. When running the test tasks, coverage reports are generated and output to the `/coverage` directory. To view the HTML report, open `/coverage/index.html` in a browser.
+
 ### Licence
 
 MIT

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "transpile": "babel index.js -o transpiled.js",
     "start": "npm run transpile; node transpiled.js test-assets/ assets.js"
   },
-  "preferGlobal": "true",
+  "preferGlobal": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/btk/pre-require.git"
@@ -36,5 +36,10 @@
     "babel-preset-stage-2": "^6.24.1"
   },
   "dependencies": {
+  },
+  "jest": {
+    "collectCoverage": true,
+    "coverageDirectory": "coverage",
+    "coverageReporters": ["html", "text", "text-summary"]
   }
 }


### PR DESCRIPTION
Was attempting to add tests for #32 and realized coverage wasn't in place. Simple update to the `package.json` to enable Jest coverage reporting.