### PR TITLE
Include required node version within package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.2.0",
   "description": "Pre-require is a small global script, helps you create a module of array object with required assets from the folder that you point out.",
   "main": "transpiled.js",
+  "engines": {
+    "node": ">=7.6"
+  },
   "bin": {
     "pre-require": "transpiled.js"
   },


### PR DESCRIPTION
The test created within #38 utilizes `async/await` which is preferred. However, it should be noted that this feature was only made available in Node v.7.6. 

This PR adds the required Node engine to the package.json file to ensure the appropriate version is installed. 