### PR TITLE
Fix #32: Improve tests for loop directory

### DIFF
--- a/lib/loop-directory.js
+++ b/lib/loop-directory.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+
+export const loopDirectory = (path, obj) => {
+    let directoryToRead = [];
+    return new Promise((resolve) => {
+        fs.readdir(path, function(err, items) {
+            items.forEach((file) => {
+                let prePath = (path[path.length - 1] == "/")?path:path+"/";
+                let stats = fs.lstatSync(prePath + file);
+                let normalizeFileName = file.replace('.', '_').replace(/-/g, '_');
+                if (stats.isDirectory()) {
+                    obj[normalizeFileName] = {};
+                    //push it to the array so that we can loop and perform recursion based on that folder
+                    directoryToRead.push({
+                        normalizeFileName,
+                        path: prePath + file
+                    });
+                } else {
+                    obj[normalizeFileName] = `require('${prePath + file}')`;
+                }
+            });
+
+            if (directoryToRead.length === 0) {
+                // if no more directory to read then we resolve it
+                resolve(obj);
+            } else {
+                // if let say more than 1 directory inside the
+                // folder then we need to resolve when everything have been resolved
+                let promises = directoryToRead.map(val => {
+                    return loopDirectory(val.path, obj[val.normalizeFileName])
+                });
+                Promise.all(promises).then(()=> {
+                    resolve(obj);
+                });
+            }
+        });
+    });
+};

--- a/lib/loop-directory.js
+++ b/lib/loop-directory.js
@@ -2,36 +2,48 @@ const fs = require('fs');
 
 export const loopDirectory = (path, obj) => {
     let directoryToRead = [];
+
     return new Promise((resolve) => {
-        fs.readdir(path, function(err, items) {
+
+        fs.readdir(path, (err, items) => {
+
             items.forEach((file) => {
-                let prePath = (path[path.length - 1] == "/")?path:path+"/";
+                let prePath = (path[path.length - 1] === "/") ? path : path + "/";
                 let stats = fs.lstatSync(prePath + file);
                 let normalizeFileName = file.replace('.', '_').replace(/-/g, '_');
+
                 if (stats.isDirectory()) {
                     obj[normalizeFileName] = {};
-                    //push it to the array so that we can loop and perform recursion based on that folder
+
+                    // push it to the array so that we can loop
+                    // and perform recursion based on that folder
                     directoryToRead.push({
                         normalizeFileName,
                         path: prePath + file
                     });
+
                 } else {
                     obj[normalizeFileName] = `require('${prePath + file}')`;
+
                 }
+
             });
 
             if (directoryToRead.length === 0) {
                 // if no more directory to read then we resolve it
                 resolve(obj);
+
             } else {
                 // if let say more than 1 directory inside the
                 // folder then we need to resolve when everything have been resolved
                 let promises = directoryToRead.map(val => {
                     return loopDirectory(val.path, obj[val.normalizeFileName])
                 });
-                Promise.all(promises).then(()=> {
-                    resolve(obj);
-                });
+
+                Promise.all(promises)
+                    .then(() => {
+                        resolve(obj);
+                    });
             }
         });
     });

--- a/tests/loop-directory.test.js
+++ b/tests/loop-directory.test.js
@@ -1,9 +1,46 @@
-import { loopDirectory } from '../index.js'
-import { assetsLength } from './utils'
+import {loopDirectory} from '../lib/loop-directory'
+import {assetsLength} from './utils'
+
+jest.mock('fs', () => {
+    const items = ['path/to/file/1', 'path/to/file/2', 'path/to/file/3'];
+
+    return {
+        readdir: jest.fn((path, cb) => {
+            cb(null, items)
+        }),
+        lstatSync: jest.fn().mockReturnValue({
+            isDirectory: jest.fn()
+        })
+    };
+});
+
+import fs from 'fs';
 
 describe('Loop directory Test', () => {
-  it('Should return the files length in folder', async () => {
-    const assets = await loopDirectory('./test-assets', {});
-    expect(assetsLength(assets)).toBe(10);
-  })
-})
+
+    let directoryItems;
+
+    beforeEach(() => {
+        directoryItems = ['path/to/file/1', 'path/to/file/2', 'path/to/file/3'];
+    });
+
+    test('should return a Promise', () => {
+        expect(loopDirectory('./test-assets', {}).then).toBeDefined();
+    });
+
+    test('should read the directory', () => {
+        const spy = jest.spyOn(fs, 'readdir');
+        const filePath = './test-assets';
+
+        loopDirectory(filePath, {});
+
+        expect(spy).toHaveBeenCalledWith(filePath, expect.any(Function));
+    });
+
+    test('Should return the files length in folder', async () => {
+        const assets = await loopDirectory('./test-assets', {});
+
+        expect(assetsLength(assets)).toEqual(directoryItems.length);
+    });
+
+});

--- a/tests/loop-directory.test.js
+++ b/tests/loop-directory.test.js
@@ -87,11 +87,25 @@ describe('Loop Directory', () => {
 
         })
 
-        test('should resolve with an object of path:require key/value pairs', async () => {
+        test('should resolve with an object of path:require key/value pairs for a flat directory', async () => {
             const assets = await loopDirectory(filePath, {});
 
             expect(assets).toEqual(expect.objectContaining({
                 'path/to/file/1': 'require(\'./test-assets/path/to/file/1\')',
+                'path/to/file/2': 'require(\'./test-assets/path/to/file/2\')',
+                'path/to/file/3': 'require(\'./test-assets/path/to/file/3\')'
+            }));
+        });
+
+        test('should resolve with an object of path:require key/value pairs for a sub-directory', async () => {
+            fs.lstatSync.mockReturnValueOnce({
+                isDirectory: jest.fn().mockReturnValueOnce(true)
+            });
+
+            const assets = await loopDirectory(filePath, {});
+
+            expect(assets).toEqual(expect.objectContaining({
+                'path/to/file/1': expect.any(Object),
                 'path/to/file/2': 'require(\'./test-assets/path/to/file/2\')',
                 'path/to/file/3': 'require(\'./test-assets/path/to/file/3\')'
             }));

--- a/tests/loop-directory.test.js
+++ b/tests/loop-directory.test.js
@@ -16,31 +16,86 @@ jest.mock('fs', () => {
 
 import fs from 'fs';
 
-describe('Loop directory Test', () => {
+describe('Loop Directory', () => {
 
+    let filePath;
     let directoryItems;
 
     beforeEach(() => {
+        filePath = './test-assets';
         directoryItems = ['path/to/file/1', 'path/to/file/2', 'path/to/file/3'];
     });
 
     test('should return a Promise', () => {
-        expect(loopDirectory('./test-assets', {}).then).toBeDefined();
+        expect(loopDirectory(filePath, {}).then).toBeDefined();
     });
 
     test('should read the directory', () => {
-        const spy = jest.spyOn(fs, 'readdir');
-        const filePath = './test-assets';
-
         loopDirectory(filePath, {});
 
-        expect(spy).toHaveBeenCalledWith(filePath, expect.any(Function));
+        expect(fs.readdir).toHaveBeenCalledWith(filePath, expect.any(Function));
     });
 
-    test('Should return the files length in folder', async () => {
+    test('should return the files length in folder', async () => {
         const assets = await loopDirectory('./test-assets', {});
 
         expect(assetsLength(assets)).toEqual(directoryItems.length);
+    });
+
+    describe('Directory Items', () => {
+
+        test('should retrieve file stats for each file within the directory', (done) => {
+            fs.lstatSync.mockClear();
+
+            loopDirectory(filePath, {})
+                .then(() => {
+                    expect(fs.lstatSync).toHaveBeenCalledTimes(directoryItems.length);
+
+                    done();
+                });
+
+
+        });
+
+        test('should append a forward slash when the provided directory path did NOT have one', (done) => {
+            const expectedPath = `${filePath}/${directoryItems[0]}`;
+
+            fs.lstatSync.mockClear();
+
+            loopDirectory(filePath, {})
+                .then(() => {
+                    expect(fs.lstatSync.mock.calls[0][0]).toEqual(expectedPath);
+
+                    done();
+                });
+
+
+        });
+
+        test('should NOT append a forward slash when the provided directory path did have one', (done) => {
+            const expectedPath = `${filePath}/${directoryItems[0]}`;
+
+            fs.lstatSync.mockClear();
+
+            loopDirectory(`${filePath}/`, {})
+                .then(() => {
+                    expect(fs.lstatSync.mock.calls[0][0]).toEqual(expectedPath);
+
+                    done();
+                });
+
+
+        })
+
+        test('should resolve with an object of path:require key/value pairs', async () => {
+            const assets = await loopDirectory(filePath, {});
+
+            expect(assets).toEqual(expect.objectContaining({
+                'path/to/file/1': 'require(\'./test-assets/path/to/file/1\')',
+                'path/to/file/2': 'require(\'./test-assets/path/to/file/2\')',
+                'path/to/file/3': 'require(\'./test-assets/path/to/file/3\')'
+            }));
+        });
     });
 
 });


### PR DESCRIPTION
Once the coverage reports were being generated with #36, I figured I'd add some tests to improve the coverage numbers.

**Changes Made**
- Abstracted the LoopDirectory function into a single file to help with maintainability
  - `lib/loop-directory.js`
- Wrote tests to cover the basic work flow: with and without sub-directories
  - `tests/loop-directory.test.js`
- Tests stub out the `fs` module to focus on the custom logic and control logic flow

**Note:** The `index.js` has NOT been modified in this PR to ensure functionality remains. I could either: 

1. remove the code from `index.js` in this PR once you approve everything is still working; OR
1. submit an additional PR to implement this new library service, and remove the duplicate code within the index.

**Coverage report - ./coverage/index.html**
```plaintext
$ npm test

> pre-require@1.2.0 test /Users/DevLab2425/pre-require
> jest

 PASS  tests/loop-directory.test.js
 PASS  tests/search-file-name.test.js

Test Suites: 2 passed, 2 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        0.796s, estimated 1s
Ran all test suites.
--------------------|----------|----------|----------|----------|----------------|
File                |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
--------------------|----------|----------|----------|----------|----------------|
All files           |    45.57 |    31.25 |       45 |    46.75 |                |
 pre-require        |    19.23 |     12.5 |     8.33 |       20 |                |
  index.js          |    19.23 |     12.5 |     8.33 |       20 |... 91,92,94,95 |
 pre-require/lib    |      100 |      100 |      100 |      100 |                |
  loop-directory.js |      100 |      100 |      100 |      100 |                |
 pre-require/tests  |     87.5 |       50 |      100 |     87.5 |                |
  utils.js          |     87.5 |       50 |      100 |     87.5 |              6 |
--------------------|----------|----------|----------|----------|----------------|

=============================== Coverage summary ===============================
Statements   : 45.57% ( 36/79 )
Branches     : 31.25% ( 10/32 )
Functions    : 45% ( 9/20 )
Lines        : 46.75% ( 36/77 )
================================================================================
```